### PR TITLE
Extract Cert manager from the teams-recording-bot chart

### DIFF
--- a/Samples/PublicSamples/RecordingBot/deploy/cert-manager/cluster-issuer.yaml
+++ b/Samples/PublicSamples/RecordingBot/deploy/cert-manager/cluster-issuer.yaml
@@ -2,15 +2,10 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt
-  namespace: {{ index .Values "cert-manager" "namespace" }}
-  labels:
-    helmVersion: {{ .Chart.Version }}
-    helmAppVersion: {{ .Chart.AppVersion }}
-    helmName: {{ .Chart.Name }}
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: {{ index .Values "cert-manager" "issuerEmail" }}
+    email: YOUR_EMAIL
     privateKeySecretRef:
       name: letsencrypt
     solvers:

--- a/Samples/PublicSamples/RecordingBot/deploy/cert-manager/install.bat
+++ b/Samples/PublicSamples/RecordingBot/deploy/cert-manager/install.bat
@@ -18,3 +18,6 @@ helm upgrade ^
 
 echo Waiting for cert-manager to be ready
 kubectl wait pod -n cert-manager --for condition=ready --timeout=60s --all
+
+echo Installing cluster issuer
+kubectl apply -f cluster-issuer.yaml

--- a/Samples/PublicSamples/RecordingBot/deploy/cert-manager/install.bat
+++ b/Samples/PublicSamples/RecordingBot/deploy/cert-manager/install.bat
@@ -1,0 +1,20 @@
+@echo off
+
+echo Updating helm repo
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+
+echo Installing cert-manager
+helm upgrade ^
+  cert-manager jetstack/cert-manager ^
+  --namespace cert-manager ^
+  --create-namespace ^
+  --version v1.13.3 ^
+  --install ^
+  --set nodeSelector."kubernetes\.io/os"=linux ^
+  --set webhook.nodeSelector."kubernetes\.io/os"=linux ^
+  --set cainjector.nodeSelector."kubernetes\.io/os"=linux ^
+  --set installCRDs=true
+
+echo Waiting for cert-manager to be ready
+kubectl wait pod -n cert-manager --for condition=ready --timeout=60s --all

--- a/Samples/PublicSamples/RecordingBot/deploy/teams-recording-bot/Chart.lock
+++ b/Samples/PublicSamples/RecordingBot/deploy/teams-recording-bot/Chart.lock
@@ -1,9 +1,6 @@
 dependencies:
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.13.2
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
   version: 4.8.3
-digest: sha256:c2ebed9bfcf0ae016d15b576453e9e42a459b1e4d4bf9c1f8ed6ef763c91f46f
-generated: "2023-11-27T14:29:26.6895132+01:00"
+digest: sha256:7dafa2cf6d937c80fb3cd1791ad242b055f9dc67931e216b6da22350c534177b
+generated: "2024-01-08T12:22:54.332827+01:00"

--- a/Samples/PublicSamples/RecordingBot/deploy/teams-recording-bot/Chart.yaml
+++ b/Samples/PublicSamples/RecordingBot/deploy/teams-recording-bot/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -24,10 +24,6 @@ version: 1.3.0
 appVersion: 1.2.0
 
 dependencies:
-  - name: cert-manager
-    version: v1.13.2
-    repository: https://charts.jetstack.io
-    alias: cert-manager
   - name: ingress-nginx
     version: 4.8.3
     repository: https://kubernetes.github.io/ingress-nginx

--- a/Samples/PublicSamples/RecordingBot/deploy/teams-recording-bot/values.yaml
+++ b/Samples/PublicSamples/RecordingBot/deploy/teams-recording-bot/values.yaml
@@ -60,19 +60,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-cert-manager:
-  namespace: cert-manager
-  installCRDs: true
-  issuerEmail: YOUR EMAIL
-  nodeSelector:
-    "kubernetes.io/os": linux
-  webhook:
-    nodeSelector:
-      "kubernetes.io/os": linux
-  caininjector:
-    nodeSelector:
-      "kubernetes.io/os": linux
-
 ingress-nginx:
   namespaceOverride: ingress-nginx
   controller:


### PR DESCRIPTION
Remove Cert-Manager from the teams-recording-bot Chart as it is a bad practise with the CRDs of the Cert Manager.
Instead add a folder dedidicated for installing the cert-manager