### PR TITLE
Undo unnecessary change to deprecated sample

### DIFF
--- a/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Http/HttpConfigurationInitializer.cs
+++ b/Samples/V1.0Samples/AksSamples(Deprecated)/teams-recording-bot/src/RecordingBot.Services/Http/HttpConfigurationInitializer.cs
@@ -34,7 +34,7 @@ namespace RecordingBot.Services.Http
         {
             HttpConfiguration httpConfig = new HttpConfiguration();
             httpConfig.MapHttpAttributeRoutes();
-            httpConfig.MessageHandlers.Add(new LoggingMessageHandler(isIncomingMessageHandler: true, logger: logger, urlIgnorers: new string[] { "/logs" }));
+            httpConfig.MessageHandlers.Add(new LoggingMessageHandler(isIncomingMessageHandler: true, logger: logger, urlIgnorers: new [] { "/logs" }));
 
             httpConfig.Services.Add(typeof(IExceptionLogger), new ExceptionLogger(logger));
 


### PR DESCRIPTION
This was previously changed by Florian, even though this change related to the deprecated sample, rather than our own.