### PR TITLE
Fix wrong VM size for windows nodepool in tutorial

### DIFF
--- a/Samples/PublicSamples/RecordingBot/docs/tutorials/deploy/1-aks.md
+++ b/Samples/PublicSamples/RecordingBot/docs/tutorials/deploy/1-aks.md
@@ -320,14 +320,15 @@ the az Azure command line tool is out of date.
 
 In the previous section, we created an AKS cluster with a linux node. However, for our recording
 bot application, we actually need a windows node instead. Let us create two new windows nodes of
-the `standard_d2s_v3`-series:
+the `standard_d4_v3`-series, this series is also available in most Microsoft Azure regions
+and meets the requirement of two physical cpu cores specified by the media SDK:
 
 ```powershell
 az aks nodepool add
     --cluster-name recordingbotcluster
     --name win22
     --resource-group recordingbottutorial
-    --node-vm-size standard_d2s_v3
+    --node-vm-size standard_d4_v3
     --node-count 2
     --os-type Windows
     --os-sku Windows2022 
@@ -388,7 +389,7 @@ This command also needs some time to complete, our result output should look sim
     "maxSurge": null,
     "nodeSoakDurationInMinutes": null
   },
-  "vmSize": "standard_d2s_v3",
+  "vmSize": "standard_d4_v3",
   "vnetSubnetId": null,
   "workloadRuntime": null
 }

--- a/Samples/PublicSamples/RecordingBot/docs/tutorials/deploy/2-acr.md
+++ b/Samples/PublicSamples/RecordingBot/docs/tutorials/deploy/2-acr.md
@@ -210,7 +210,7 @@ After that the execution of the command takes some time and results in an output
         "maxSurge": null,
         "nodeSoakDurationInMinutes": null
       },
-      "vmSize": "standard_d2s_v3",
+      "vmSize": "standard_d4_v3",
       "vnetSubnetId": null,
       "windowsProfile": {},
       "workloadRuntime": null


### PR DESCRIPTION
As found in #61 the tutorial specifies a wrong VM size for the windows nodepool, which results in not starting pods, this updates the tutorial to use correct vm sizes.